### PR TITLE
Accessing root fields through REST api. (Issue #37)

### DIFF
--- a/src/server/rest.cpp
+++ b/src/server/rest.cpp
@@ -9,6 +9,7 @@ namespace ouroboros
 {
 	static const char * full_regex = "^/groups/([a-z0-9-_]+)/fields/([a-z0-9-_]+)/?$";
 	static const char * group_regex = "^/groups/([a-z0-9-_]+)/?$";
+	static const char * root_field_regex = "^/fields/([a-z0-9-_]+)/?$";
 
 	bool is_REST_URI(const std::string& aURI)
 	{
@@ -16,15 +17,19 @@ namespace ouroboros
 			slre_match(full_regex, aURI.c_str(), aURI.length(), NULL, 0, 0);
 		int group_result =
 			slre_match(group_regex, aURI.c_str(), aURI.length(), NULL, 0, 0);
-
-		return (result >= 0 || group_result >= 0);
+		int root_field_result =
+			slre_match(root_field_regex, aURI.c_str(), aURI.length(), NULL, 0, 0);
+	
+		return (result >= 0 || group_result >= 0 || root_field_result >= 0);
 	}
 
 	REST_call_type get_REST_call_type(const std::string& aURI)
 	{	
 		int item_result = slre_match(
 			full_regex, aURI.c_str(), aURI.length(), NULL, 0, 0);
-		if (item_result >= 0)
+		int root_item_result = slre_match(
+			root_field_regex, aURI.c_str(), aURI.length(), NULL, 0, 0);
+		if (item_result >= 0 || root_item_result >= 0)
 			return REST_call_type::NAME;
 		
 		int group_result = slre_match(
@@ -58,18 +63,30 @@ namespace ouroboros
 
 	std::pair<std::string, std::string> extract_group_name(const std::string& aURI)
 	{
-		struct slre_cap match[2];
-		slre_match(full_regex, aURI.c_str(), aURI.length(), match, 2, 0);
+		//Check if user is accessing field in root first
+		struct slre_cap match[1];
+		if(slre_match(root_field_regex, aURI.c_str(), aURI.length(), match, 1, 0)){
+			std::pair<std::string, std::string> result;
+			//Root group is "server"
+			result.first.assign("server");
+			result.second.assign(match[0].ptr, match[0].len);
+			
+			return result;
+		}
+		else{
+			struct slre_cap match[2];
+			slre_match(full_regex, aURI.c_str(), aURI.length(), match, 2, 0);
 
-		std::pair<std::string, std::string> result;
-		
-		//Copy group title from match to remove remaining characters
-		std::string groupTitle(match[0].ptr);
-		groupTitle.erase(groupTitle.begin()+match[0].len, groupTitle.end());
+			std::pair<std::string, std::string> result;
+			
+			//Copy group title from match to remove remaining characters
+			std::string groupTitle(match[0].ptr);
+			groupTitle.erase(groupTitle.begin()+match[0].len, groupTitle.end());
 
-		result.first.assign(groupTitle);
-		result.second.assign(match[1].ptr, match[1].len);
-		return result;
+			result.first.assign(groupTitle);
+			result.second.assign(match[1].ptr, match[1].len);
+			return result;
+		}
 	}
 
 	std::string extract_group(const std::string& aURI)

--- a/src/server/rest.cpp
+++ b/src/server/rest.cpp
@@ -64,11 +64,10 @@ namespace ouroboros
 	std::pair<std::string, std::string> extract_group_name(const std::string& aURI)
 	{
 		std::pair<std::string, std::string> result;
-		struct slre_cap match[1];
+		
 		//Check if user is accessing field in root first
+		struct slre_cap match[1];
 		if(slre_match(root_field_regex, aURI.c_str(), aURI.length(), match, 1, 0) >= 0){
-			//struct slre_cap match[1];
-			//slre_match(root_field_regex, aURI.c_str(), aURI.length(), match, 1, 0);	
 			//Root group is "server"
 			result.first.assign("server");
 			result.second.assign(match[0].ptr, match[0].len);

--- a/src/server/rest.cpp
+++ b/src/server/rest.cpp
@@ -10,7 +10,8 @@ namespace ouroboros
 	static const char * full_regex = "^/groups/([a-z0-9-_]+)/fields/([a-z0-9-_]+)/?$";
 	static const char * group_regex = "^/groups/([a-z0-9-_]+)/?$";
 	static const char * root_field_regex = "^/fields/([a-z0-9-_]+)/?$";
-
+	static const char * root_group_regex = "^/groups/?$";
+	
 	bool is_REST_URI(const std::string& aURI)
 	{
 		int result =
@@ -19,8 +20,11 @@ namespace ouroboros
 			slre_match(group_regex, aURI.c_str(), aURI.length(), NULL, 0, 0);
 		int root_field_result =
 			slre_match(root_field_regex, aURI.c_str(), aURI.length(), NULL, 0, 0);
-	
-		return (result >= 0 || group_result >= 0 || root_field_result >= 0);
+		int root_group_result =
+			slre_match(root_group_regex, aURI.c_str(), aURI.length(), NULL, 0, 0);
+
+		return (result >= 0 || group_result >= 0
+			       || root_field_result >= 0 || root_group_result);
 	}
 
 	REST_call_type get_REST_call_type(const std::string& aURI)
@@ -34,7 +38,9 @@ namespace ouroboros
 		
 		int group_result = slre_match(
 			group_regex, aURI.c_str(), aURI.length(), NULL, 0, 0);
-		if (group_result >= 0)
+		int root_group_result = slre_match(
+			root_group_regex, aURI.c_str(), aURI.length(), NULL, 0, 0);
+		if (group_result >= 0 || root_group_result >= 0)
 			return REST_call_type::GROUP;
 		
 		return REST_call_type::NONE;
@@ -91,13 +97,13 @@ namespace ouroboros
 	std::string extract_group(const std::string& aURI)
 	{
 		struct slre_cap match[1];
-		slre_match(group_regex, aURI.c_str(), aURI.length(), match, 1, 0);
-
 		std::string result;
-		result.assign(match[0].ptr, match[0].len);
-		
-		if(result != "server"){
+		if(slre_match(group_regex, aURI.c_str(), aURI.length(), match, 1, 0) >= 0){
+			result.assign(match[0].ptr, match[0].len);	
 			result.insert(0, "server-");
+		}
+		else{
+			result.assign("server");
 		}
 
 		return result;

--- a/src/server/rest.cpp
+++ b/src/server/rest.cpp
@@ -63,30 +63,30 @@ namespace ouroboros
 
 	std::pair<std::string, std::string> extract_group_name(const std::string& aURI)
 	{
-		//Check if user is accessing field in root first
+		std::pair<std::string, std::string> result;
 		struct slre_cap match[1];
-		if(slre_match(root_field_regex, aURI.c_str(), aURI.length(), match, 1, 0)){
-			std::pair<std::string, std::string> result;
+		//Check if user is accessing field in root first
+		if(slre_match(root_field_regex, aURI.c_str(), aURI.length(), match, 1, 0) >= 0){
+			//struct slre_cap match[1];
+			//slre_match(root_field_regex, aURI.c_str(), aURI.length(), match, 1, 0);	
 			//Root group is "server"
 			result.first.assign("server");
 			result.second.assign(match[0].ptr, match[0].len);
-			
-			return result;
 		}
 		else{
 			struct slre_cap match[2];
 			slre_match(full_regex, aURI.c_str(), aURI.length(), match, 2, 0);
-
-			std::pair<std::string, std::string> result;
-			
+						
 			//Copy group title from match to remove remaining characters
 			std::string groupTitle(match[0].ptr);
 			groupTitle.erase(groupTitle.begin()+match[0].len, groupTitle.end());
+			groupTitle.insert(0, "server-");
 
 			result.first.assign(groupTitle);
-			result.second.assign(match[1].ptr, match[1].len);
-			return result;
+			result.second.assign(match[1].ptr, match[1].len);	
 		}
+
+		return result;
 	}
 
 	std::string extract_group(const std::string& aURI)
@@ -96,6 +96,11 @@ namespace ouroboros
 
 		std::string result;
 		result.assign(match[0].ptr, match[0].len);
+		
+		if(result != "server"){
+			result.insert(0, "server-");
+		}
+
 		return result;
 	}
 	

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -62,8 +62,8 @@ int main(void) {
 	mg_set_option(server, "listening_port", "8080");  // Open port 8080
 
 	for (;;) {
-    mg_poll_server(server, 1000);   // Infinite loop, Ctrl-C to stop
-  }
+    		mg_poll_server(server, 1000);   // Infinite loop, Ctrl-C to stop
+  	}
 	mg_destroy_server(&server);
 
 	return 0;


### PR DESCRIPTION
Modified the REST api to accept root fields without requiring specification that they are in the root group (server).
 
example: localhost:8080/fields/a_string