### PR TITLE
Changed namespace delimiter refactoring ("::" is a bad idea).

### DIFF
--- a/src/server/data/data_store.hpp
+++ b/src/server/data/data_store.hpp
@@ -18,6 +18,9 @@ namespace ouroboros
 	class data_store
 	{
 	public:
+		
+		static const std::string group_delimiter;
+		
 		/**	Initializes the data_store by moving a group into its control.
 		 * 
 		 *	@param [in] aRoot Group to be moved (i.e. std::move) into the control of

--- a/src/server/data/data_store.ipp
+++ b/src/server/data/data_store.ipp
@@ -44,7 +44,7 @@ namespace ouroboros
 		const group<T>* result = NULL;
 		//Check that the group string is valid syn
 		//Break aGroup into tokens
-		std::vector<std::string> groups = detail::split(aGroup, "-");
+		std::vector<std::string> groups = detail::split(aGroup, group_delimiter);
 		
 		
 		if (!groups.empty())
@@ -69,4 +69,7 @@ namespace ouroboros
 		}
 		return result;
 	}
+	
+	template <class T>
+	const std::string data_store<T>::group_delimiter("::");
 }

--- a/src/server/data/data_store.ipp
+++ b/src/server/data/data_store.ipp
@@ -71,5 +71,5 @@ namespace ouroboros
 	}
 	
 	template <class T>
-	const std::string data_store<T>::group_delimiter("::");
+	const std::string data_store<T>::group_delimiter("-");
 }

--- a/src/server/ouroboros_server.cpp
+++ b/src/server/ouroboros_server.cpp
@@ -185,7 +185,7 @@ namespace ouroboros
 		std::string result = "server";
 		if(!aGroup.empty())
 		{
-			result += "-" + aGroup;
+			result += group_delimiter + aGroup;
 		}
 		
 		return result;
@@ -244,4 +244,6 @@ namespace ouroboros
 	
 		return NULL;
 	}
+	
+	const std::string ouroboros_server::group_delimiter(data_store<var_field>::group_delimiter);
 }

--- a/src/server/ouroboros_server.h
+++ b/src/server/ouroboros_server.h
@@ -31,6 +31,8 @@ namespace ouroboros
 		void register_callback(const std::string& aGroup, const std::string& aField, Func aCallback);
 		
 	private:
+		
+		static const std::string group_delimiter;
 		static void* run_server(void*);
 		
 		mg_result handle_uri(mg_connection *conn, const std::string& uri);

--- a/src/server/rest.cpp
+++ b/src/server/rest.cpp
@@ -7,7 +7,7 @@
 
 namespace ouroboros
 {
-	static const std::string character_set("[a-z0-9-_:]");
+	static const std::string character_set("[a-z0-9-_]");
 	static const std::string full_regex("^/groups/(" + character_set + "+)/fields/(" + character_set + "+)/?$");
 	static const std::string group_regex("^/groups/(" + character_set + "+)/?$");
 	static const std::string root_field_regex("^/fields/(" + character_set + "+)/?$");

--- a/src/server/rest.cpp
+++ b/src/server/rest.cpp
@@ -7,10 +7,11 @@
 
 namespace ouroboros
 {
-	static const char * full_regex = "^/groups/([a-z0-9-_]+)/fields/([a-z0-9-_]+)/?$";
-	static const char * group_regex = "^/groups/([a-z0-9-_]+)/?$";
-	static const char * root_field_regex = "^/fields/([a-z0-9-_]+)/?$";
-	static const char * root_group_regex = "^/groups/?$";
+	static const std::string character_set("[a-z0-9-_:]");
+	static const std::string full_regex("^/groups/(" + character_set + "+)/fields/(" + character_set + "+)/?$");
+	static const std::string group_regex("^/groups/(" + character_set + "+)/?$");
+	static const std::string root_field_regex("^/fields/(" + character_set + "+)/?$");
+	static const std::string root_group_regex("^/groups/?$");
 	
 	/**	Extracts the group from the given REST URI.
 	 * 
@@ -35,13 +36,13 @@ namespace ouroboros
 	bool is_REST_URI(const std::string& aURI)
 	{
 		int result =
-			slre_match(full_regex, aURI.c_str(), aURI.length(), NULL, 0, 0);
+			slre_match(full_regex.c_str(), aURI.c_str(), aURI.length(), NULL, 0, 0);
 		int group_result =
-			slre_match(group_regex, aURI.c_str(), aURI.length(), NULL, 0, 0);
+			slre_match(group_regex.c_str(), aURI.c_str(), aURI.length(), NULL, 0, 0);
 		int root_field_result =
-			slre_match(root_field_regex, aURI.c_str(), aURI.length(), NULL, 0, 0);
+			slre_match(root_field_regex.c_str(), aURI.c_str(), aURI.length(), NULL, 0, 0);
 		int root_group_result =
-			slre_match(root_group_regex, aURI.c_str(), aURI.length(), NULL, 0, 0);
+			slre_match(root_group_regex.c_str(), aURI.c_str(), aURI.length(), NULL, 0, 0);
 
 		return (result >= 0 || group_result >= 0
 			       || root_field_result >= 0 || root_group_result);
@@ -50,16 +51,16 @@ namespace ouroboros
 	static rest_request_type get_rest_request_type(const std::string& aURI)
 	{	
 		int item_result = slre_match(
-			full_regex, aURI.c_str(), aURI.length(), NULL, 0, 0);
+			full_regex.c_str(), aURI.c_str(), aURI.length(), NULL, 0, 0);
 		int root_item_result = slre_match(
-			root_field_regex, aURI.c_str(), aURI.length(), NULL, 0, 0);
+			root_field_regex.c_str(), aURI.c_str(), aURI.length(), NULL, 0, 0);
 		if (item_result >= 0 || root_item_result >= 0)
 			return FIELDS;
 		
 		int group_result = slre_match(
-			group_regex, aURI.c_str(), aURI.length(), NULL, 0, 0);
+			group_regex.c_str(), aURI.c_str(), aURI.length(), NULL, 0, 0);
 		int root_group_result = slre_match(
-			root_group_regex, aURI.c_str(), aURI.length(), NULL, 0, 0);
+			root_group_regex.c_str(), aURI.c_str(), aURI.length(), NULL, 0, 0);
 		if (group_result >= 0 || root_group_result >= 0)
 			return GROUPS;
 		
@@ -93,7 +94,7 @@ namespace ouroboros
 
 		//Check if user is accessing field in root first
 		struct slre_cap match[1];
-		if(slre_match(root_field_regex, aURI.c_str(), aURI.length(), match, 1, 0) >= 0)
+		if(slre_match(root_field_regex.c_str(), aURI.c_str(), aURI.length(), match, 1, 0) >= 0)
 		{
 			result.first = std::string();
 			result.second.assign(match[0].ptr, match[0].len);
@@ -101,7 +102,7 @@ namespace ouroboros
 		else
 		{
 			struct slre_cap match[2];
-			slre_match(full_regex, aURI.c_str(), aURI.length(), match, 2, 0);
+			slre_match(full_regex.c_str(), aURI.c_str(), aURI.length(), match, 2, 0);
 
 			//Copy group title from match to remove remaining characters
 			std::string groupTitle(match[0].ptr);
@@ -118,7 +119,7 @@ namespace ouroboros
 	{
 		struct slre_cap match[1];
 		std::string result;
-		if(slre_match(group_regex, aURI.c_str(), aURI.length(), match, 1, 0) >= 0)
+		if(slre_match(group_regex.c_str(), aURI.c_str(), aURI.length(), match, 1, 0) >= 0)
 		{
 			result.assign(match[0].ptr, match[0].len);	
 		}


### PR DESCRIPTION
ouroboros_server::group_delimiter is defined in terms of
data_store<T>::group_delimiter, which is defined to be "::".

REST constants were changed from const char* to std::string, and a new
constant was defined, character_set, which defines which characters a
REST query will accept.