### PR TITLE
clang fixes.

### DIFF
--- a/src/server/Makefile.am
+++ b/src/server/Makefile.am
@@ -8,4 +8,5 @@ libouroboros_a_SOURCES = ouroboros_server.h device_tree.cpp  device_tree.hpp  de
 bin_PROGRAMS = ouroboros_server
 ouroboros_server_LDADD = libouroboros.a data/libJSON.a data/libdata.a $(top_builddir)/lib/libmongoose.a $(top_builddir)/lib/libslre.a $(top_builddir)/lib/libfrozen.a -ldl
 ouroboros_server_SOURCES = main.cpp
-ouroboros_server_CXXFLAGS = $(AM_CXXFLAGS) -Wl,--export-dynamic
+ouroboros_server_LDFLAGS = -export-dynamic
+ouroboros_server_CXXFLAGS = $(AM_CXXFLAGS)

--- a/src/server/callback.hpp
+++ b/src/server/callback.hpp
@@ -46,3 +46,4 @@ namespace ouroboros
 #include "callback.ipp"
 
 #endif//_OUROBOROS_CALLBACK_H_
+

--- a/src/server/ouroboros_server.ipp
+++ b/src/server/ouroboros_server.ipp
@@ -20,3 +20,4 @@ namespace ouroboros
 		return named;
 	}
 }
+


### PR DESCRIPTION
Made sure that the project can be compiled by clang, and fixed a few
warnings emitted by clang in the process.

This should be tested by someone using Mac OS X to be sure.

Fixes issue #96 (hopefully).