### PR TITLE
Callback generalization

### DIFF
--- a/src/server/callback.hpp
+++ b/src/server/callback.hpp
@@ -5,7 +5,7 @@
 
 namespace ouroboros
 {
-	template <typename Func>
+	template <typename Item, typename Func>
 	class callback
 	{
 	public:
@@ -18,18 +18,7 @@ namespace ouroboros
 		 *		where the first parameter is the group and the second parameter
 		 *		the field that is being observed.
 		 */
-		callback(const std::string& aGroup, Func aFunc);
-		
-		/**	Constructor
-		 *
-		 *	@param [in] aGroup Group to listen to for changes.
-		 *	@param [in] aField Field to listen to for changes.
-		 *	@param [in] aFunc Functor to register for the callback. The functor
-		 *		must behave as a void(std::string, std::string) functions,
-		 *		where the first parameter is the group and the second parameter
-		 *		the field that is being observed.
-		 */
-		callback(const std::string& aGroup, const std::string& aField, Func aFunc);
+		callback(const Item& aItem, Func aFunc);
 		
 		/**	Function called by others as a callback.
 		 *
@@ -37,9 +26,47 @@ namespace ouroboros
 		void operator()() const;
 		
 	private:
+		Item mItem;
 		Func mFunc;
-		std::string mGroup;
-		std::string mField;
+	};
+	
+	template <typename Item, typename Func, typename Cond>
+	class conditional_callback
+	{
+	public:
+		
+		/**	Constructor.
+		 *
+		 *	@param [in] aGroup Group to listen to for changes.
+		 *	@param [in] aFunc Functor to register for the callback. The functor
+		 *		must behave as a void(std::string, std::string) functions,
+		 *		where the first parameter is the group and the second parameter
+		 *		the field that is being observed.
+		 *	@param [in] aCond Functor that evaluates to true when the callback
+		 *		should be triggered, and false otherwise. The functor must
+		 *		behave as a bool(const Item&) function, where Item is the type
+		 *		of the object being compared.
+		 */
+		conditional_callback(const Item& aItem, Func aFunc, Cond aCond);
+		
+		/**	Function called by others as a callback.
+		 *
+		 */
+		void operator()() const;
+		
+	private:
+		Item mItem;
+		Func mFunc;
+		Cond mCond;
+	};
+	
+	template <typename Item, typename Cond>
+	class conditional
+	{
+	public:
+		conditional(Cond aConditional);
+		bool operator()(const Item& aItem) const;
+	private:
 	};
 }
 

--- a/src/server/callback.hpp
+++ b/src/server/callback.hpp
@@ -12,7 +12,7 @@ namespace ouroboros
 		
 		/**	Constructor.
 		 *
-		 *	@param [in] aGroup Group to listen to for changes.
+		 *	@param [in] aItem Item to execute the callback on.
 		 *	@param [in] aFunc Functor to register for the callback. The functor
 		 *		must behave as a void(std::string, std::string) functions,
 		 *		where the first parameter is the group and the second parameter
@@ -37,7 +37,7 @@ namespace ouroboros
 		
 		/**	Constructor.
 		 *
-		 *	@param [in] aGroup Group to listen to for changes.
+		 *	@param [in] aItem Item to execute the callback on.
 		 *	@param [in] aFunc Functor to register for the callback. The functor
 		 *		must behave as a void(std::string, std::string) functions,
 		 *		where the first parameter is the group and the second parameter

--- a/src/server/callback.hpp
+++ b/src/server/callback.hpp
@@ -18,7 +18,7 @@ namespace ouroboros
 		 *		where the first parameter is the group and the second parameter
 		 *		the field that is being observed.
 		 */
-		callback(const Item& aItem, Func aFunc);
+		callback(Item aItem, Func aFunc);
 		
 		/**	Function called by others as a callback.
 		 *
@@ -28,45 +28,6 @@ namespace ouroboros
 	private:
 		Item mItem;
 		Func mFunc;
-	};
-	
-	template <typename Item, typename Func, typename Cond>
-	class conditional_callback
-	{
-	public:
-		
-		/**	Constructor.
-		 *
-		 *	@param [in] aItem Item to execute the callback on.
-		 *	@param [in] aFunc Functor to register for the callback. The functor
-		 *		must behave as a void(std::string, std::string) functions,
-		 *		where the first parameter is the group and the second parameter
-		 *		the field that is being observed.
-		 *	@param [in] aCond Functor that evaluates to true when the callback
-		 *		should be triggered, and false otherwise. The functor must
-		 *		behave as a bool(const Item&) function, where Item is the type
-		 *		of the object being compared.
-		 */
-		conditional_callback(const Item& aItem, Func aFunc, Cond aCond);
-		
-		/**	Function called by others as a callback.
-		 *
-		 */
-		void operator()() const;
-		
-	private:
-		Item mItem;
-		Func mFunc;
-		Cond mCond;
-	};
-	
-	template <typename Item, typename Cond>
-	class conditional
-	{
-	public:
-		conditional(Cond aConditional);
-		bool operator()(const Item& aItem) const;
-	private:
 	};
 }
 

--- a/src/server/callback.ipp
+++ b/src/server/callback.ipp
@@ -3,7 +3,7 @@
 namespace ouroboros
 {
 	template <typename Item, typename Func>
-	callback<Item, Func>::callback(const Item& aItem, Func aFunc)
+	callback<Item, Func>::callback(Item aItem, Func aFunc)
 	:mItem(aItem), mFunc(aFunc)
 	{}
 		
@@ -11,19 +11,5 @@ namespace ouroboros
 	void callback<Item, Func>::operator()() const
 	{
 		mFunc(mItem);
-	}
-	
-	template <typename Item, typename Func, typename Cond>
-	conditional_callback<Item, Func, Cond>::conditional_callback(const Item& aItem, Func aFunc, Cond aCond)
-	:mItem(aItem), mFunc(aFunc), mCond(aCond)
-	{}
-	
-	template <typename Item, typename Func, typename Cond>
-	void conditional_callback<Item, Func, Cond>::operator()() const
-	{
-		if (mCond(mItem))
-		{
-			mFunc(mItem);
-		}
 	}
 }

--- a/src/server/callback.ipp
+++ b/src/server/callback.ipp
@@ -2,20 +2,28 @@
 
 namespace ouroboros
 {
-	template <typename Func>
-	callback<Func>::callback(const std::string& aGroup, Func aFunc)
-	:mFunc(aFunc), mGroup(aGroup)
-	{}
-	
-	template <typename Func>
-	callback<Func>::callback(
-		const std::string& aGroup, const std::string& aField, Func aFunc)
-	:mFunc(aFunc), mGroup(aGroup), mField(aField)
+	template <typename Item, typename Func>
+	callback<Item, Func>::callback(const Item& aItem, Func aFunc)
+	:mItem(aItem), mFunc(aFunc)
 	{}
 		
-	template <typename Func>
-	void callback<Func>::operator()() const
+	template <typename Item, typename Func>
+	void callback<Item, Func>::operator()() const
 	{
-		mFunc(mGroup, mField);
+		mFunc(mItem);
+	}
+	
+	template <typename Item, typename Func, typename Cond>
+	conditional_callback<Item, Func, Cond>::conditional_callback(const Item& aItem, Func aFunc, Cond aCond)
+	:mItem(aItem), mFunc(aFunc), mCond(aCond)
+	{}
+	
+	template <typename Item, typename Func, typename Cond>
+	void conditional_callback<Item, Func, Cond>::operator()() const
+	{
+		if (mCond(mItem))
+		{
+			mFunc(mItem);
+		}
 	}
 }

--- a/src/server/ouroboros_server.cpp
+++ b/src/server/ouroboros_server.cpp
@@ -226,6 +226,24 @@ namespace ouroboros
 			return MG_FALSE;
 		}
 	}
+	
+	bool ouroboros_server::register_callback(const std::string& aGroup, const std::string& aField, callback_function aCallback)
+	{
+		var_field *named = mStore.get(normalize_group(aGroup), aField);
+		if (named)
+		{
+			std::string key(aGroup+"/"+aField);
+			if (!mCallbackSubjects.count(key))
+			{
+				
+				mCallbackSubjects[key] = subject<callback<var_field*, callback_function> >();
+			}
+			
+			callback<var_field*, callback_function> cb(named, aCallback);
+			mCallbackSubjects[key].registerObserver(cb);
+		}
+		return named;
+	}
 
 	const std::string ouroboros_server::group_delimiter(data_store<var_field>::group_delimiter);
 }

--- a/src/server/ouroboros_server.h
+++ b/src/server/ouroboros_server.h
@@ -113,8 +113,8 @@ namespace ouroboros
 		mg_server *mpServer;
 		data_store<var_field>& mStore;
 		
-		typedef void (*callback_function)(const std::string& aGroup, const std::string& aField);
-		std::map<std::string, subject<callback<callback_function> > > mCallbackSubjects;
+		typedef void (*callback_function)(var_field* aField);
+		std::map<std::string, subject<callback<var_field*, callback_function> > > mCallbackSubjects;
 		void handle_notification(const std::string& aGroup, const std::string& aField);
 		
 	};

--- a/src/server/ouroboros_server.h
+++ b/src/server/ouroboros_server.h
@@ -14,6 +14,9 @@ namespace ouroboros
 	class ouroboros_server
 	{
 	public:
+		
+		typedef void (*callback_function)(var_field* aField);
+		
 		/**	Constructor.
 		 * 
 		 *	Prepares server to run.
@@ -87,8 +90,7 @@ namespace ouroboros
 		 *		function.
 		 *	@returns True upon success, false otherwise.
 		 */
-		template <typename Func>
-		bool register_callback(const std::string& aGroup, const std::string& aField, Func aCallback);
+		bool register_callback(const std::string& aGroup, const std::string& aField, callback_function aCallback);
 		
 	private:
 		
@@ -113,13 +115,10 @@ namespace ouroboros
 		mg_server *mpServer;
 		data_store<var_field>& mStore;
 		
-		typedef void (*callback_function)(var_field* aField);
 		std::map<std::string, subject<callback<var_field*, callback_function> > > mCallbackSubjects;
 		void handle_notification(const std::string& aGroup, const std::string& aField);
 		
 	};
 }
-
-#include <server/ouroboros_server.ipp>
 
 #endif//_OUROBOROS_OUROBOROS_SERVER_

--- a/src/server/ouroboros_server.ipp
+++ b/src/server/ouroboros_server.ipp
@@ -1,21 +1,5 @@
 namespace ouroboros
 {
-	template <typename Func>
-	bool ouroboros_server::register_callback(const std::string& aGroup, const std::string& aField, Func aCallback)
-	{
-		var_field *named = mStore.get(normalize_group(aGroup), aField);
-		if (named)
-		{
-			std::string key(aGroup+"/"+aField);
-			if (!mCallbackSubjects.count(key))
-			{
-				mCallbackSubjects[key] = subject<callback<var_field*, Func> >();
-			}
-			
-			callback<var_field*, Func> cb(named, aCallback);
-			mCallbackSubjects[key].registerObserver(cb);
-		}
-		return named;
-	}
+	
 }
 

--- a/src/server/ouroboros_server.ipp
+++ b/src/server/ouroboros_server.ipp
@@ -3,18 +3,16 @@ namespace ouroboros
 	template <typename Func>
 	bool ouroboros_server::register_callback(const std::string& aGroup, const std::string& aField, Func aCallback)
 	{
-		
 		var_field *named = mStore.get(normalize_group(aGroup), aField);
 		if (named)
 		{
 			std::string key(aGroup+"/"+aField);
-			
 			if (!mCallbackSubjects.count(key))
 			{
-				mCallbackSubjects[key] = subject<callback<Func> >();
+				mCallbackSubjects[key] = subject<callback<var_field*, Func> >();
 			}
 			
-			callback<Func> cb(aGroup, aField, aCallback);
+			callback<var_field*, Func> cb(named, aCallback);
 			mCallbackSubjects[key].registerObserver(cb);
 		}
 		return named;

--- a/src/server/plugin/test.cpp
+++ b/src/server/plugin/test.cpp
@@ -7,10 +7,10 @@
 using namespace ouroboros;
 using namespace std;
 
-void callback(const std::string& aGroup, const std::string& aField)
+void callback(var_field* aField)
 {
 	cout << "we got a callback!!!" << endl;
-	cout << "\tHappened at: " << aGroup << '\\' << aField << endl;
+	cout << "\tHappened at: " << aField->getTitle() << endl;
 }
 
 
@@ -20,7 +20,7 @@ extern "C" bool plugin_entry(ouroboros_server& aServer)
 	cout << "Initializing plugin..." << endl;
 
 	aServer.register_callback("", "a_number", ::callback);
-	aServer.register_callback("group_1-group_2", "a_string_inside_group_2", ::callback);
+	aServer.register_callback("group_1.group_2", "a_string_inside_group_2", ::callback);
 
 	cout << "Done initializing." << endl;
 	return true;

--- a/src/server/plugin/test.cpp
+++ b/src/server/plugin/test.cpp
@@ -3,6 +3,7 @@
 #include "test.h"
 #include <server/plugin.h>
 #include <iostream>
+#include "../data/base_integer.h"
 
 using namespace ouroboros;
 using namespace std;
@@ -12,8 +13,6 @@ void callback(var_field* aField)
 	cout << "we got a callback!!!" << endl;
 	cout << "\tHappened at: " << aField->getTitle() << endl;
 }
-
-
 
 extern "C" bool plugin_entry(ouroboros_server& aServer)
 {


### PR DESCRIPTION
This work generalizes callbacks. It was meant to also introduce conditionals, but after some thinking and testing (and limitations), I decided to not implement them. The amount of code being executed for conditionals would be the same whether we or users implement conditionals, and if they implement it themselves, they can choose what data to look at and store, etc., while if we did it, we are forced to specify a hard number of function parameters they could pass for conditionals, i.e. if we did it, users would have less flexibility and would probably implement their own anyway.

Hopefully this addresses #43.