### PR TITLE
Memory cleanups and improvements to interface

### DIFF
--- a/src/ouroboros/data/base.hpp
+++ b/src/ouroboros/data/base.hpp
@@ -203,6 +203,9 @@ namespace ouroboros
 		const group<T> *findGroup(const std::string& aName) const;
 		//@}
 
+		std::vector<T*> getFields() const;
+		std::vector<group<T>*> getGroups() const;
+		
 		/**	Gets the number of groups and items found within the group.
 		 *
 		 *	@returns The number of groups and items found within the group.

--- a/src/ouroboros/data/base.ipp
+++ b/src/ouroboros/data/base.ipp
@@ -140,5 +140,29 @@ namespace ouroboros
 		result += " } }";
 		return result;
 	}
+	
+	template<class T>
+	std::vector<T*> group<T>::getFields() const
+	{
+		std::vector<T*> result;
+		typedef typename std::map<std::string, T*>::const_iterator iter;
+		for (iter itr = mItems.begin(); itr != mItems.end(); ++itr)
+		{
+			result.push_back(itr->second);
+		}
+		return result;
+	}
+
+	template<class T>
+	std::vector<group<T>*> group<T>::getGroups() const
+	{
+		std::vector<group<T>*> result;
+		typedef typename std::map<std::string, group<T>*>::const_iterator iter;
+		for (iter itr = mGroups.begin(); itr != mGroups.end(); ++itr)
+		{
+			result.push_back(itr->second);
+		}
+		return result;
+	}
 
 }

--- a/src/ouroboros/device_tree.hpp
+++ b/src/ouroboros/device_tree.hpp
@@ -15,12 +15,12 @@ namespace ouroboros
 	class device_tree
 	{
 	public:
-		/**	Gets the instance of the device_tree.
-		 *
-		 *	@returns The instance of the device_tree.
-		 */
-		static device_tree& get_device_tree();
 
+		/**	Construct a new device_tree using a brand new data_store.
+		 * 
+		 */
+		device_tree();
+		
 		/**	Gets the data_store object holding all of the data.
 		 *
 		 *	@returns The data_store object holding all of the data.
@@ -42,9 +42,10 @@ namespace ouroboros
 		/**	This class can only be instantiated by itself.
 		 *
 		 */
-		device_tree();
-		static device_tree *mpTree;
+		
+		device_tree *mpTree;
 
+		group<field> mRootGroup;
 		data_store<field> *mpDataStore;
 		function_manager mFunctionManager;
 	};

--- a/src/ouroboros/device_tree.ipp
+++ b/src/ouroboros/device_tree.ipp
@@ -5,21 +5,10 @@
 namespace ouroboros
 {
 	template <class field>
-	device_tree<field>& device_tree<field>::get_device_tree()
-	{
-		if (!mpTree)
-		{
-			mpTree = new device_tree<field>();
-		}
-		return *mpTree;
-	}
-
-	template <class field>
 	device_tree<field>::device_tree()
+	:mRootGroup(detail::build_tree<field>(mFunctionManager))
 	{
-		mpDataStore =
-			new data_store<field>(
-				detail::build_tree<field>(mFunctionManager));
+		mpDataStore = new data_store<field>(mRootGroup);
 	}
 
 	template <class field>
@@ -27,6 +16,7 @@ namespace ouroboros
 	{
 		//we need to free all of the resources we've allocated
 		delete mpDataStore;
+		detail::free_tree(mRootGroup);
 	}
 
 	template <class field>
@@ -40,7 +30,4 @@ namespace ouroboros
 	{
 		return mFunctionManager;
 	}
-
-	template<class field>
-	device_tree<field> *device_tree<field>::mpTree;
 }

--- a/src/ouroboros/device_tree.tpp
+++ b/src/ouroboros/device_tree.tpp
@@ -10,5 +10,12 @@ namespace ouroboros
 		 */
 		template<class field>
 		group<field> build_tree(function_manager& aFunctionManager);
+		
+		/**	Frees the data tree used by the main data_store instance.
+		 *	NOTE: This function is to be templated by code generator.
+		 *
+		 */
+		template<class field>
+		void free_tree(group<field>& aRoot);
 	}
 }

--- a/src/ouroboros/ouroboros_server.cpp
+++ b/src/ouroboros/ouroboros_server.cpp
@@ -34,9 +34,9 @@ namespace ouroboros
 	std::string url_regex("(.+://)?(.+)");
 
 	ouroboros_server::ouroboros_server(uint16_t aPort)
-	:mpServer(NULL),
-		mStore(device_tree<var_field>::get_device_tree().get_data_store()),
-		mFunctionManager(device_tree<var_field>::get_device_tree().get_function_manager())
+	:mpServer(NULL), mTree(),
+		mStore(mTree.get_data_store()),
+		mFunctionManager(mTree.get_function_manager())
 	{
 
 		//The following line is a hack workaround to trying to avoid using
@@ -274,8 +274,10 @@ namespace ouroboros
 				}
 					break;
 
-				case DELETE:
+				//TODO DELETE is not supported by the underlying mechanism
+				/*case DELETE:
 				{
+					
 					//Send JSON describing named item
 					std::string data(conn->content, conn->content_len);
 					JSON json(data);
@@ -283,7 +285,7 @@ namespace ouroboros
 					std::string id = json.get("id");
 					unregister_callback(id);
 					response = detail::good_JSON();
-				}
+				}*/
 					break;
 
 				default:

--- a/src/ouroboros/ouroboros_server.h
+++ b/src/ouroboros/ouroboros_server.h
@@ -8,6 +8,7 @@
 #include <ouroboros/data/data_store.hpp>
 #include <ouroboros/data/subject.hpp>
 #include <ouroboros/function_manager.h>
+#include <ouroboros/device_tree.hpp>
 
 #include <pthread.h>
 #include <mongoose/mongoose.h>
@@ -160,6 +161,7 @@ namespace ouroboros
 		//@}
 
 		mg_server *mpServer;
+		device_tree<var_field> mTree;
 		data_store<var_field>& mStore;
 
 		function_manager &mFunctionManager;

--- a/src/serverconfig.xml
+++ b/src/serverconfig.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <deviceConfig>
-	<libraries>
-		<files>myfile.h</files>
-	</libraries>
+
 	<group>
-   		<title>Home</title>
+		<title>Home</title>
 		<description>
-			This is Home
+			This is the Home group.
 		</description>
+		
 		<field type="signedIntField">
 			<title>A number</title>
 			<description>
@@ -24,10 +23,32 @@
 			</description>
 			<value>hello</value>
 		</field>
+
+		<field type="enumField">
+			<title>An enum</title>
+			<description>
+				An enum for use in the program.
+			</description>
+			<value>Enum1</value>
+			<value>Enum2</value>
+			<value>Enum3</value>
+			<value>Enum4</value>
+			<value>Enum5</value>
+		</field>
+		
+		<field type="booleanField">
+			<title>A boolean</title>
+			<description>
+				An boolean for use in the program.
+			</description>
+			<value>true</value>
+		</field>
+
 	</group>
 
 	<group>
-   	<title>General</title>
+
+   		<title>General</title>
 		<description>
 			This is General, a top level nav item.
 		</description>
@@ -44,6 +65,40 @@
 					A string for use in the program.
 				</description>
 				<value>hello</value>
+			</field>
+
+			<field type="floatField">
+				<title>A float</title>
+				<description>
+					A floating number
+				</description>
+				<value>
+					12345.6789
+				</value>
+
+				<min>
+					0
+				</min>
+				<max>
+					1000000000
+				</max>
+			</field>
+
+			<field type="doubleField">
+				<title>A double</title>
+				<description>
+					A double precision number
+				</description>
+				<value>
+					9876.5432
+				</value>
+
+				<min>
+					-1000000000
+				</min>
+				<max>
+					1000000000
+				</max>
 			</field>
 
 			<group>
@@ -70,61 +125,8 @@
 			</description>
 			<value>hello</value>
 		</field>
-	</group>
-
-	<field type="booleanField">
-		<title>A boolean</title>
-		<description>
-		Desc?
-		</description>
-		<value>ASKDHLAKS</value>
-	</field>
 		
-	<field type="signedIntField">
-		<title>A number2</title>
-		<description>
-			A number for use in the program.
-		</description>
-		<value>20</value>
-	</field>
-	
-	<field type="doubleField">
-		<title>A number 3</title>
-		<description>
-			A number for use in the program.
-		</description>
-		<value>20</value>
-	</field>
-	
-	<field type="stringField">
-		<title>A string</title>
-		<description>
-			A string for use in the program.
-		</description>
-		<value>hello</value>
-		<minLength>2</minLength>
-		<maxLength>12</maxLength>
-	</field>
-	
-	<field type="functionField">
-		<title>func</title>
-		<description>func</description>
-		<params>
-			<param>
-				a
-			</param>
-			<param>
-				b
-			</param>
-		</params>
-	</field>
-
-	<field type="enumField">
-		<title>An enum</title>
-		<description>dur</description>
-		<value>One</value>
-		<value>Two</value>
-	</field>
+	</group>
 
 </deviceConfig>
 

--- a/src/templates/code/device_tree.tpl
+++ b/src/templates/code/device_tree.tpl
@@ -20,6 +20,26 @@
 	{<%iinc%>
 		namespace detail
 		{<%iinc%>
+			
+			template<>
+			void free_tree(group<var_field>& aRoot)
+			{<%iinc%>
+				std::vector<var_field*> currentFields = aRoot.getFields();
+				std::vector<group<var_field>*> currentGroups =
+					aRoot.getGroups();
+				
+				for (std::size_t i = 0; i < currentFields.size(); ++i)
+				{<%iinc%>
+					delete currentFields[i];
+				<%idec%>}
+				
+				for (std::size_t i = 0; i < currentGroups.size(); ++i)
+				{<%iinc%>
+					free_tree(*currentGroups[i]);
+					delete currentGroups[i];
+				<%idec%>}
+			<%idec%>}
+			
 			template<>
 			group<var_field> build_tree(function_manager& aManager)
 			{<%iinc%>	


### PR DESCRIPTION
Changed things around so that we no longer have memory leaks. The
generator now generates a second function which is responsible for
freeing up all the memory allocated by build_tree.

In addition, group gained two new methods, that return a vector of the
fields and groups immediately within it.